### PR TITLE
Refactor duplicate comment in issues script

### DIFF
--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -20,6 +20,14 @@ TOKEN = os.getenv("GITHUB_TOKEN")
 
 headers = {"Authorization": f"token {TOKEN}", "Accept": "application/vnd.github.v3+json"}
 
+# Default comment used when closing duplicate issues.
+DUPLICATE_COMMENT = (
+    "Thanks for trying aider and filing this issue.\n\n"
+    "This looks like a duplicate of #{number}, so I'm going to close it so "
+    "discussion can happen there. Please let me know if you think it's actually "
+    "a distinct issue."
+)
+
 
 def get_issues(state="open"):
     issues = []
@@ -83,12 +91,7 @@ def comment_and_close_duplicate(issue, oldest_issue):
     )
     close_url = f"{GITHUB_API_URL}/repos/{REPO_OWNER}/{REPO_NAME}/issues/{issue['number']}"
 
-    comment_body = (
-        "Thanks for trying aider and filing this issue.\n\n"
-        f"This looks like a duplicate of #{oldest_issue['number']}, so I'm going to close it so"
-        " discussion can happen there. Please let me know if you think it's actually a distinct"
-        " issue."
-    )
+    comment_body = DUPLICATE_COMMENT.format(number=oldest_issue["number"])
 
     # Post comment
     response = requests.post(comment_url, headers=headers, json={"body": comment_body})


### PR DESCRIPTION
## Summary
- promote duplicate issue comment to a constant
- format the constant when creating comment text

## Testing
- `pre-commit run --files scripts/issues.py` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(fails: `pytest: command not found`)*